### PR TITLE
réorganisation du code pour que "cargo doc" génère l'énoncé de l'exercice

### DIFF
--- a/src/exercice.rs
+++ b/src/exercice.rs
@@ -1,0 +1,163 @@
+//! Contient toutes les fonctions que vous devez écrire.
+#![allow(non_snake_case, unused_imports)]
+
+use super::Node;
+use bitvec::vec::BitVec;
+use std::{
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap},
+};
+
+/// Compte le nombre d'apparition de chaque caractère dans l'entrée.
+///
+/// # Retourne
+///
+/// Une [table de hachage](HashMap) possédant un couple (clé, valeur)
+/// pour chaque caractère présent dans `input`,
+/// où la clé est le caractère, et où la valeur est son nombre d'apparitions.
+///
+/// # Indications
+///
+/// Utilisez la méthode [chars](str::chars) des [chaînes de caractères](str),
+/// et éventuellement la méthode [entry](HashMap::entry) des [tables de hachage](HashMap).
+
+pub fn a__scan_char_frequencies(input: &str) -> HashMap<char, usize> {
+    // Remplacez la ligne ci-dessous par votre code
+    solution::a__scan_char_frequencies(input)
+}
+
+//
+
+/// Étant donnés un texte à compresser,
+/// et une table de hachage contenant le code binaire de chaque caractere,
+/// génère le code binaire de de l'entrée compressée.
+///
+/// # Exemple
+///
+/// Si l'entrée est `"aabaabbcab"` et que les codes sont `0` pour `'a'`,
+/// `10` pour `'b'` et `11` pour `'c'`,
+/// on doit obtenir `001000101011010`.
+///
+/// # Note: `BitVec`
+///
+/// la classe [`BitVec`] est definie dans une [crate](bitvec) à part,
+/// et possède une interace similaire à celle d'un [vecteurs](Vec)
+/// de la bibliothèque standard dont les éléments seraient des booléens.
+
+pub fn b__compress_text(input: &str, codes: &HashMap<char, BitVec>) -> BitVec {
+    // Remplacez la ligne ci-dessous par votre code
+    solution::b__compress_text(input, codes)
+}
+
+//
+
+/// Consruit l'arbre de Huffman correspondant aux nombre d'apparitions de caractères donnés en entrée.
+///
+/// # Méthode
+///
+/// Un nœud de l'arbre (classe [Node])
+/// est soit une feuille contenant un caractère,
+/// soit un nœud interne contenant exactement 2 enfants.
+///
+/// Pour chaque caractère de l'entrée,
+/// on crée un tuple composé du nombre d'apparition et d'un nœud
+/// [feuille](Node::Leaf) contenant ce caractère.
+/// On insère tout ce beau monde dan un tas binaire
+/// (classe [BinaryHeap] de la bibliothèque standard).
+///
+/// Ensuite, tant que la taille du tas est supérieure à 1,
+/// on extrait du tas les 2 noeuds dont les nombres d'apparitions sont les plus faibles,
+/// on les fusionne en créant un nouveau nœud interne
+/// (dont le nombre d'apparitions est la somme de ceux des deux nœuds extraits).
+/// On insère ce nouveau nœud dans le tas.
+///
+/// Lorsque le tas atteint une taille de 1,
+/// il contient la racine de l'arbre.
+///
+/// # Exemple
+///
+/// Si on part de a:5, b:3, c:1,
+/// le tas contient initialement 3 nœuds.
+/// On extrait c:1 et b:3, que l'on fusionne dans un nouveau nœud de poids 4.
+/// Le tas contient désormais a:5 et (c^b):4.
+/// On extrait ces deux noeuds, que l'on fusionne (en un nœud de poids 9).
+/// Ce nouveau nœud est maintenant seul dans le tas, c'est la racine de l'arbre,
+/// dont la structure est la suivante :
+///
+/// ```text
+///          /\
+///         /  \
+///        /\   a
+///       /  \
+///      c    b
+/// ```
+///
+/// # Note
+///
+/// Le paramètre `frequencies` peut être produit par la fonction
+/// [`a__scan_char_frequencies`] précédemment écrite.
+
+pub fn c__build_huffman_tree(frequencies: &HashMap<char, usize>) -> Box<Node> {
+    // Remplacez la ligne ci-dessous par votre code
+    solution::c__build_huffman_tree(frequencies)
+}
+
+//
+
+/// Retourne, pour un arbre de Huffman,
+/// une table de hachage associant à chaque caractère de l'arbre son code.
+///
+/// # Méthode
+///
+/// Pour trouver le code d'un caractère,
+/// il suffit de regarder le chemin de la racine jusqu'à sa feuille.
+/// Lorsqu'on part à droite on compte 1, et 0 lorsqu'on part à gauche.
+///
+/// # Exemple
+///
+/// Avec l'arbre ci-dessous, le code de `'a'` est donc `1`,
+/// le code de `'b'` est `01`, et le code de `'c'` est `00`.
+///
+/// ```text
+///          /\
+///         /  \
+///        /\   a
+///       /  \
+///      c    b
+/// ```
+///
+/// # Note
+///
+/// Le paramètre d'entrée  `root` peut être produit par la fonction
+/// [`c__build_huffman_tree`] précédemment écrite.
+///
+/// La valeur de retour de cette fonction est utilisable en entrée
+/// (paramètre `codes`) de la fonction [`b__compress_text`].
+
+pub fn d__build_codes(root: &Node) -> HashMap<char, BitVec> {
+    // Remplacez la ligne ci-dessous par votre code
+    solution::d__build_codes(root)
+}
+
+//
+
+/// À partir d'un texte compressé et de l'arbre de Huffman lui correspondant,
+/// reconstruit le texte original.
+///
+/// # Méthode
+///
+/// Cette fonction doit parcourir l'arbre `htree` depuis la racine;
+/// en fonction des bits contenus dans `ctext`.
+/// Chaque fois qu'elle atteint une feuille de l'arbre,
+/// elle doit produire le caractère correspondant,
+/// et repartir de la racine de l'arbre,
+/// jusqu'à arriver à la fin de `ctext`.
+
+pub fn e__decompress(ctext: &BitVec, htree: &Node) -> String {
+    // Remplacez la ligne ci-dessous par votre code
+    solution::e__decompress(ctext, htree)
+}
+
+//
+
+use super::solution;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,44 @@
+//! # Exercice: Codage de Huffman en Rust
+//!
+//! Cet exercice est disponible ici: <https://github.com/wagnerf42/huffman/>.
+//!
+//! Lancer `cargo test` pour tester les différentes fonctions ;
+//! `cargo test <nom_de_fonction>` permet de ne tester que la fonction en question.
+//!
+//! `cargo run` permet de tester l'ensemble:
+//! * `cargo run compress <source_file> <destination_file>` pour compresser un fichier
+//! * `cargo run decompress <compressed_file> [destination_file]` pour décompresser un fichier
+//!   (affiche le résultat sur la sortie standard en l'absence de fichier destination)
+//!
+//! ## Votre travail
+//!
+//! Implémenter, dans l'ordre où elle sont données,
+//! toutes les fonctions spécifiées dans le [src/exercice.rs](exercice).
+//!
+//! ## Références
+//!
+//! [Codage de Huffman sur Wikipedia](https://fr.wikipedia.org/wiki/Codage_de_Huffman)
+
 use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
     env::args,
     fs::File,
     io::{self, Write},
 };
 
+pub mod exercice;
 mod solution;
 
-fn scan_char_frequencies(input: &str) -> HashMap<char, usize> {
-    solution::scan_char_frequencies(input)
-}
-
+/// Un nœud de l'arbre de Huffman.
+///
+/// Peut être une [feuille](Node::Leaf) ou un [nœud interne](Node::Internal).
 #[derive(Serialize, Deserialize, Debug, PartialOrd, Eq, PartialEq, Ord)]
 pub enum Node {
+    /// Une feuille de l'arbre de Huffman
     Leaf(char),
+    /// Un nœud interne de l'arbre de Huffman, possédant deux nœuds enfants.
     Internal([Box<Node>; 2]),
-}
-
-fn build_huffman_tree(frequencies: &HashMap<char, usize>) -> Box<Node> {
-    solution::build_huffman_tree(frequencies)
-}
-
-fn build_codes(root: &Node) -> HashMap<char, BitVec> {
-    solution::build_codes(root)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -35,15 +49,15 @@ pub struct CompressedText {
 
 impl CompressedText {
     fn new(input: &str) -> Self {
-        let frequencies = scan_char_frequencies(input);
-        let htree = build_huffman_tree(&frequencies);
-        let codes = build_codes(&htree);
-        let ctext = compress_text(input, &codes);
+        let frequencies = exercice::a__scan_char_frequencies(input);
+        let htree = exercice::c__build_huffman_tree(&frequencies);
+        let codes = exercice::d__build_codes(&htree);
+        let ctext = exercice::b__compress_text(input, &codes);
         CompressedText { htree, ctext }
     }
 
     fn decompress(&self) -> String {
-        solution::decompress(&self.ctext, &self.htree)
+        exercice::e__decompress(&self.ctext, &self.htree)
     }
 
     fn load(file_name: &str) -> io::Result<Self> {
@@ -57,10 +71,6 @@ impl CompressedText {
         writer.write_all(&encoded)?;
         Ok(())
     }
-}
-
-fn compress_text(input: &str, codes: &HashMap<char, BitVec>) -> BitVec {
-    solution::compress_text(input, codes)
 }
 
 fn main() -> io::Result<()> {

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -1,3 +1,6 @@
+//! Contient les solutions.
+#![allow(non_snake_case)]
+
 use std::{
     cmp::Reverse,
     collections::{BinaryHeap, HashMap},
@@ -11,7 +14,99 @@ use itertools::{
 
 pub use crate::{CompressedText, Node};
 
-pub fn scan_char_frequencies(input: &str) -> HashMap<char, usize> {
+/*
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+*/
+
+pub(crate) fn a__scan_char_frequencies(input: &str) -> HashMap<char, usize> {
     input.chars().fold(HashMap::new(), |mut h, c| {
         *h.entry(c).or_default() += 1;
         h
@@ -110,7 +205,7 @@ pub fn scan_char_frequencies(input: &str) -> HashMap<char, usize> {
 
 */
 
-pub fn build_huffman_tree(frequencies: &HashMap<char, usize>) -> Box<Node> {
+pub(crate) fn c__build_huffman_tree(frequencies: &HashMap<char, usize>) -> Box<Node> {
     let mut heap: BinaryHeap<(Reverse<usize>, Box<Node>)> = frequencies
         .iter()
         .map(|(c, count)| (Reverse(*count), Box::new(Node::Leaf(*c))))
@@ -205,7 +300,7 @@ pub fn build_huffman_tree(frequencies: &HashMap<char, usize>) -> Box<Node> {
 
 */
 
-pub fn build_codes(root: &Node) -> HashMap<char, BitVec> {
+pub(crate) fn d__build_codes(root: &Node) -> HashMap<char, BitVec> {
     let mut codes = HashMap::new();
     fn build_codes_recursively(
         root: &Node,
@@ -301,7 +396,7 @@ pub fn build_codes(root: &Node) -> HashMap<char, BitVec> {
 
 */
 
-pub fn compress_text(input: &str, codes: &HashMap<char, BitVec>) -> BitVec {
+pub(crate) fn b__compress_text(input: &str, codes: &HashMap<char, BitVec>) -> BitVec {
     input.chars().flat_map(|c| &codes[&c]).collect()
 }
 
@@ -401,7 +496,7 @@ pub fn compress_text(input: &str, codes: &HashMap<char, BitVec>) -> BitVec {
 
 */
 
-pub fn decompress(ctext: &BitVec, htree: &Node) -> String {
+pub(crate) fn e__decompress(ctext: &BitVec, htree: &Node) -> String {
     ctext
         .iter()
         .batching(|it| {

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,13 +2,13 @@ use bitvec::vec::BitVec;
 use std::collections::HashMap;
 use test_case::test_case;
 
-use crate::solution::*;
+use crate::{exercice::*, Node};
 
 #[test_case("foo", &[('f', 1), ('o', 2)]; "foo")]
 #[test_case("hello world", &[('h', 1), ('e', 1), ('l', 3), ('o', 2), (' ', 1), ('w', 1), ('r', 1), ('d', 1), ]; "hello world")]
 #[test_case("aabaabbcab", &[('a', 5), ('b', 4), ('c', 1), ]; "aabaabbcab")]
 fn test_scan_char_frequencies(txt: &str, exp: &[(char, usize)]) {
-    let got = scan_char_frequencies(txt);
+    let got = a__scan_char_frequencies(txt);
     let exp: HashMap<char, usize> = exp.iter().copied().collect();
     assert_eq!(&got, &exp);
 }
@@ -18,7 +18,7 @@ fn test_scan_char_frequencies(txt: &str, exp: &[(char, usize)]) {
 #[test_case("aabaabbcab", &["a 0", "b 10", "c 11"], "001000101011010"; "aabaabbcab")]
 fn test_compress_text(txt: &str, codes: &[&str], exp: &str) {
     let codes = codes.iter().map(str2cb).collect();
-    let got = compress_text(txt, &codes);
+    let got = b__compress_text(txt, &codes);
     let exp = str2bitvec(exp);
     assert_eq!(got, exp);
 }
@@ -27,7 +27,7 @@ fn test_compress_text(txt: &str, codes: &[&str], exp: &str) {
 #[test_case(&[('a', 5), ('b', 4), ('c', 1)], "c b . a ."; "aabaabbcab")]
 fn test_build_huffman_tree(freqs: &[(char, usize)], exp: &str) {
     let freqs = freqs.iter().copied().collect();
-    let got = *build_huffman_tree(&freqs);
+    let got = *c__build_huffman_tree(&freqs);
     let exp = str2tree(exp);
     assert_eq!(got, exp);
 }
@@ -37,7 +37,7 @@ fn test_build_huffman_tree(freqs: &[(char, usize)], exp: &str) {
 #[test_case("c b . a .", &["c 00", "b 01", "a 1"]; "aabaabbcab_2")]
 fn test_build_codes(htree: &str, exp: &[&str]) {
     let htree = &str2tree(htree);
-    let got = build_codes(htree);
+    let got = d__build_codes(htree);
     let exp = exp.iter().map(str2cb).collect();
     assert_eq!(got, exp);
 }
@@ -49,7 +49,7 @@ fn test_build_codes(htree: &str, exp: &[&str]) {
 fn test_decompress(ctext: &str, htree: &str, exp: &str) {
     let ctext = str2bitvec(ctext);
     let htree = str2tree(htree);
-    let got = decompress(&ctext, &htree);
+    let got = e__decompress(&ctext, &htree);
     assert_eq!(got, exp);
 }
 


### PR DESCRIPTION
un exemple du résultat est disponible ici :

https://champin.net/2023/rust-grenoble/huffman/

NB: pour que les fonctions apparaissent dans le bon ordre dans la doc,
j'ai dû les préfixer par a__, b__, etc...
C'est pas génial, mais je n'ai pas trouvé mieux...